### PR TITLE
Refactor main.py to be modular

### DIFF
--- a/asn.csv
+++ b/asn.csv
@@ -1,0 +1,3 @@
+number,title,country
+111111,Test title,AA
+999999,Test title,ZZ

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def upload_manifest(tmp_dir):
 def create_redshift_tables():
     conn = connRedshift.connect()
     tablenames = [
-        'dim_risk', 'logentry', 'count', 'tmp_count'
+        'dim_risk', 'logentry', 'count'
     ]
     drop_tables(conn, tablenames)
     create_logentry = dedent('''
@@ -123,13 +123,6 @@ def create_redshift_tables():
     asn BIGINT, count INT, count_amplified FLOAT
     )
     ''')
-    create_tmp_count = dedent('''
-    CREATE TABLE tmp_count(
-    ip VARCHAR(32), date TIMESTAMP, risk INT,
-    asn BIGINT, country VARCHAR(2)
-    )
-    ''')
-    conn.execute(create_tmp_count)
     conn.execute(create_risk)
     conn.execute(create_logentry)
     conn.execute(create_count)
@@ -183,16 +176,12 @@ def aggregate():
     conn = connRedshift.connect()
     print('Aggregating ...')
     query = dedent('''
-    INSERT INTO tmp_count
-    SELECT DISTINCT (ip), date_trunc('day', date) AS date, risk, asn, country FROM logentry
-    ''')
-    conn.execute(query)
-    query = dedent('''
     INSERT INTO count
-    SELECT
+    (SELECT
         date, risk, country, asn, count(*) as count, 0 as count_amplified
-    FROM tmp_count
-    GROUP BY date, asn, risk, country ORDER BY date DESC, country ASC, asn ASC, risk ASC
+    FROM(
+    SELECT DISTINCT (ip), date_trunc('day', date) AS date, risk, asn, country FROM logentry) AS foo
+    GROUP BY date, asn, risk, country ORDER BY date DESC, country ASC, asn ASC, risk ASC)
     ''')
     conn.execute(query)
     conn.close()
@@ -458,6 +447,6 @@ def run_rds(tmpdir):
 
 if __name__ == '__main__':
     tmpdir = tempfile.mkdtemp()
-    run_redshift(tmpdir)
+    # run_redshift(tmpdir)
     run_rds(tmpdir)
     shutil.rmtree(tmpdir)

--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ import json
 import csv
 import os
 
-
 #utils
 def rpath(*args):
     return join(dirname(__file__), *args)
@@ -49,404 +48,422 @@ def split_s3_path(s3_address):
     return (s3_bucket, s3_path)
 
 
-config = load_config(rpath('config.json'))
-
-CYBERGREEN_SOURCE_ROOT = config['source_path']
-CYBERGREEN_DEST_ROOT = config['dest_path']
-REDSHIFT_ROLE_ARN = config['role_arn']
-REDSHIFT_URI = config['redshift_uri']
-RDS_URI = config['rds_uri']
-REF_DATA_URLS = [inventory['url'] for inventory in config['inventory']]
-# AWS credentials
-AWS_ACCESS_KEY = config['access_key']
-AWS_ACCESS_SECRET_KEY = config['secret_key']
-# set connections
-connRedshift = create_engine(REDSHIFT_URI,
-                             isolation_level='AUTOCOMMIT')
-connRDS = create_engine(RDS_URI)
-conns3 = boto3.resource('s3',
-    aws_access_key_id=AWS_ACCESS_KEY,
-    aws_secret_access_key=AWS_ACCESS_SECRET_KEY
-)
+class Aggregator(object):
+    def __init__(self, config):
+        self.config = config
+        self.tmpdir = tempfile.mkdtemp()
+        self.connRedshift = create_engine(
+            config.get('redshift_uri'),
+            isolation_level='AUTOCOMMIT'
+        )
+        self.conns3 = boto3.resource(
+            's3',
+            aws_access_key_id=config.get('access_key'),
+            aws_secret_access_key=config.get('secret_key')
+        )
 
 
-def create_manifest(datapackage,source):
-    datapackage = json.loads(datapackage)
-    manifest = {"entries": []}
-    keys = (p['path'] for p in datapackage['resources'])
-    for key_list in keys:
-        for key in key_list:
-            manifest['entries'].append({"url": join(source,key), "mandatory": True})
-    return manifest
+    def run(self):
+        table_name = 'count'
+        self.upload_manifest()
+        self.create_tables()
+        self.load_ref_data()
+        self.load_data()
+        self.count_data()
+        self.aggregate()
+        self.update_amplified_count()
+        self.unload(table_name)
+        self.drop_tables(self.connRedshift.connect(), [
+            'dim_risk', 'logentry', 'count'
+        ])
+        shutil.rmtree(self.tmpdir)
 
 
-def upload_manifest(tmp_dir):
-    tmp_manifest = join(tmp_dir,'clean.manifest')
-    s3bucket, key = split_s3_path(CYBERGREEN_SOURCE_ROOT)
-    dp_key = join(key, 'datapackage.json')
-    obj = conns3.Object(s3bucket, dp_key)
-    dp = obj.get()['Body'].read()
-    manifest = create_manifest(dp,CYBERGREEN_SOURCE_ROOT)
-
-    f = open(tmp_manifest, 'w')
-    json.dump(manifest, f)
-    f.close()
-
-    key = join(key, 'clean.manifest')
-    obj = conns3.Object(s3bucket, key)
-    obj.put(Body=open(tmp_manifest))
-    print('Manifest Updated')
+    def drop_tables(self, cursor, tables):
+        for tablename in tables:
+            cursor.execute(
+                "DROP TABLE IF EXISTS %(table)s CASCADE",
+                {"table": AsIs(tablename)}
+            )
 
 
-### LOAD, AGGREGATION, UNLOAD
-def create_redshift_tables():
-    conn = connRedshift.connect()
-    tablenames = [
-        'dim_risk', 'logentry', 'count'
-    ]
-    drop_tables(conn, tablenames)
-    create_logentry = dedent('''
-    CREATE TABLE logentry(
-    date TIMESTAMP, ip VARCHAR(32), risk INT,
-    asn BIGINT, country VARCHAR(2)
-    )
-    ''')
-    create_risk = dedent('''
-    CREATE TABLE dim_risk(
-    id INT, slug VARCHAR(32), title VARCHAR(32),
-    amplification_factor FLOAT, description TEXT
-    )
-    ''')
-    create_count = dedent('''
-    CREATE TABLE count(
-    date TIMESTAMP, risk INT, country VARCHAR(2),
-    asn BIGINT, count INT, count_amplified FLOAT
-    )
-    ''')
-    conn.execute(create_risk)
-    conn.execute(create_logentry)
-    conn.execute(create_count)
-    conn.close()
-    print('Redshift tables created')
+    def create_manifest(self, datapackage, source):
+        datapackage = json.loads(datapackage)
+        manifest = {"entries": []}
+        keys = (p['path'] for p in datapackage.get('resources'))
+        for key_list in keys:
+            for key in key_list:
+                manifest['entries'].append({"url": join(source,key), "mandatory": True})
+        return manifest
 
 
-def load_data():
-    conn = connRedshift.connect()
-    manifest = join(CYBERGREEN_SOURCE_ROOT, 'clean.manifest')
-    copycmd = dedent('''
-    COPY logentry FROM '%s'
-    CREDENTIALS 'aws_iam_role=%s'
-    IGNOREHEADER AS 1
-    DELIMITER ',' gzip
-    TIMEFORMAT AS 'auto'
-    MANIFEST
-    ''')
-    print('Loading data into db ... ')
-    conn.execute(copycmd%(manifest, REDSHIFT_ROLE_ARN))
-    conn.close()
-    print('Data Loaded')
+    def upload_manifest(self):
+        tmp_manifest = join(self.tmpdir,'clean.manifest')
+        s3bucket, key = split_s3_path(self.config.get('source_path'))
+        dp_key = join(key, 'datapackage.json')
+        obj = self.conns3.Object(s3bucket, dp_key)
+        dp = obj.get()['Body'].read()
+        manifest = self.create_manifest(dp, self.config.get('source_path'))
+
+        f = open(tmp_manifest, 'w')
+        json.dump(manifest, f)
+        f.close()
+
+        key = join(key, 'clean.manifest')
+        obj = self.conns3.Object(s3bucket, key)
+        obj.put(Body=open(tmp_manifest))
+        print('Manifest Updated')
 
 
-def load_ref_data(config=config):
-    conn = connRedshift.connect()
-    url = ''
-    for inv in config['inventory']:
-        if inv['name'] == 'risk':
-            url = inv['url']
-    dp = datapackage.DataPackage(url)
-    risks = dp.resources[0].data
-    query = dedent('''
-    INSERT INTO dim_risk
-    VALUES (%(id)s, %(slug)s, %(title)s, %(amplification_factor)s, %(description)s)''')
-    for risk in risks:
-        # description is too long and not needed here
-        risk['description']=''
-        conn.execute(query,risk)
-    conn.close()
+    def create_tables(self):
+        conn = self.connRedshift.connect()
+        tablenames = [
+            'dim_risk', 'logentry', 'count'
+        ]
+        self.drop_tables(conn, tablenames)
+        create_logentry = dedent('''
+        CREATE TABLE logentry(
+        date TIMESTAMP, ip VARCHAR(32), risk INT,
+        asn BIGINT, country VARCHAR(2)
+        )
+        ''')
+        create_risk = dedent('''
+        CREATE TABLE dim_risk(
+        id INT, slug VARCHAR(32), title VARCHAR(32),
+        amplification_factor FLOAT, description TEXT
+        )
+        ''')
+        create_count = dedent('''
+        CREATE TABLE count(
+        date TIMESTAMP, risk INT, country VARCHAR(2),
+        asn BIGINT, count INT, count_amplified FLOAT
+        )
+        ''')
+        conn.execute(create_risk)
+        conn.execute(create_logentry)
+        conn.execute(create_count)
+        conn.close()
+        print('Redshift tables created')
 
 
-def count_data():
-    cmd = 'SELECT count(*) FROM logentry'
-    cursor = connRedshift.raw_connection().cursor()
-    cursor.execute(cmd)
-    print(cursor.fetchone())
+    def load_data(self):
+        conn = self.connRedshift.connect()
+        manifest = join(self.config.get('source_path'), 'clean.manifest')
+        copycmd = dedent('''
+        COPY logentry FROM '%s'
+        CREDENTIALS 'aws_iam_role=%s'
+        IGNOREHEADER AS 1
+        DELIMITER ',' gzip
+        TIMEFORMAT AS 'auto'
+        MANIFEST
+        ''')
+        print('Loading data into db ... ')
+        conn.execute(copycmd%(manifest, self.config.get('role_arn')))
+        conn.close()
+        print('Data Loaded')
 
 
-def aggregate():
-    conn = connRedshift.connect()
-    print('Aggregating ...')
-    query = dedent('''
-    INSERT INTO count
-    (SELECT
-        date, risk, country, asn, count(*) as count, 0 as count_amplified
-    FROM(
-    SELECT DISTINCT (ip), date_trunc('day', date) AS date, risk, asn, country FROM logentry) AS foo
-    GROUP BY date, asn, risk, country ORDER BY date DESC, country ASC, asn ASC, risk ASC)
-    ''')
-    conn.execute(query)
-    conn.close()
+    def load_ref_data(self):
+        conn = self.connRedshift.connect()
+        url = ''
+        for inv in self.config.get('inventory'):
+            if inv.get('name') == 'risk':
+                url = inv.get('url')
+        dp = datapackage.DataPackage(url)
+        risks = dp.resources[0].data
+        query = dedent('''
+        INSERT INTO dim_risk
+        VALUES (%(id)s, %(slug)s, %(title)s, %(amplification_factor)s, %(description)s)''')
+        for risk in risks:
+            # description is too long and not needed here
+            risk['description']=''
+            conn.execute(query,risk)
+        conn.close()
 
 
-def update_amplified_count():
-    conn = connRedshift.connect()
-    print('Calculating Amplificated Counts ...')
-    query = dedent('''
-    UPDATE count
-    SET count_amplified = count*amplification_factor
-    FROM dim_risk WHERE risk=id
-    ''')
-    conn.execute(query)
-    conn.close()
-    print('Aggregation Finished!')
+    def count_data(self):
+        cmd = 'SELECT count(*) FROM logentry'
+        cursor = self.connRedshift.raw_connection().cursor()
+        cursor.execute(cmd)
+        print(cursor.fetchone())
 
 
-def unload(table):
-    conn = connRedshift.connect()
-    aws_auth_args = 'aws_access_key_id=%s;aws_secret_access_key=%s'%\
-        (AWS_ACCESS_KEY, AWS_ACCESS_SECRET_KEY)
-    conn.execute(dedent('''
-    UNLOAD('SELECT * FROM count')
-    TO '%s'
-    CREDENTIALS '%s'
-    DELIMITER AS ','
-    ALLOWOVERWRITE
-    PARALLEL OFF
-    ''')%(join(CYBERGREEN_DEST_ROOT, table), aws_auth_args))
-    conn.close()
-
-    bucket, key = split_s3_path(CYBERGREEN_DEST_ROOT)
-    add_extention(bucket, '%s000'%(join(key, table)))
-    delete_key(bucket, '%s000'%(join(key, table)))
-    print('Data Unloaded To s3')
+    def aggregate(self):
+        conn = self.connRedshift.connect()
+        print('Aggregating ...')
+        query = dedent('''
+        INSERT INTO count
+        (SELECT
+            date, risk, country, asn, count(*) as count, 0 as count_amplified
+        FROM(
+        SELECT DISTINCT (ip), date_trunc('day', date) AS date, risk, asn, country FROM logentry) AS foo
+        GROUP BY date, asn, risk, country ORDER BY date DESC, country ASC, asn ASC, risk ASC)
+        ''')
+        conn.execute(query)
+        conn.close()
 
 
-def add_extention(bucket, key):
-    copy_source = {
-        'Bucket': bucket,
-        'Key': key
-    }
-    new_key = '%s.csv'%(key.split('0')[0])
-    conns3.meta.client.copy(copy_source, bucket, new_key)
+    def update_amplified_count(self):
+        conn = self.connRedshift.connect()
+        print('Calculating Amplificated Counts ...')
+        query = dedent('''
+        UPDATE count
+        SET count_amplified = count*amplification_factor
+        FROM dim_risk WHERE risk=id
+        ''')
+        conn.execute(query)
+        conn.close()
+        print('Aggregation Finished!')
 
 
-def delete_key(bucket, key):
-    conns3.Object(bucket, key).delete()
+    def unload(self, table):
+        conn = self.connRedshift.connect()
+        aws_auth_args = 'aws_access_key_id=%s;aws_secret_access_key=%s'%\
+            (self.config.get('access_key'), self.config.get('secret_key'))
+        conn.execute(dedent('''
+        UNLOAD('SELECT * FROM count')
+        TO '%s'
+        CREDENTIALS '%s'
+        DELIMITER AS ','
+        ALLOWOVERWRITE
+        PARALLEL OFF
+        ''')%(join(self.config.get('dest_path'), table), aws_auth_args))
+        conn.close()
+
+        bucket, key = split_s3_path(self.config.get('dest_path'))
+        self.add_extention(bucket, '%s000'%(join(key, table)))
+        self.delete_key(bucket, '%s000'%(join(key, table)))
+        print('Data Unloaded To s3')
 
 
-### LOAD FROM S3 TO RDS
-def download_and_load(tmp):
-    print('Downloading csv file ...')
-    bucket, key = split_s3_path(CYBERGREEN_DEST_ROOT)
-    s3paths = [
-        (join(tmp,'count.csv'),join(key,'count.csv'))
-    ]
-    bucket = conns3.Bucket(bucket)
-    for path in s3paths: 
-        bucket.download_file(path[1], path[0])
-    
-    print('Loading into RDS ...')
-    copy_command = dedent('''
-    psql {uri} -c "\COPY fact_count FROM {tmp}/count.csv WITH delimiter as ',' null '' csv;"
-    ''')
-    os.system(copy_command.format(tmp=tmp,uri=config['rds_uri']))
+    def add_extention(self, bucket, key):
+        copy_source = {
+            'Bucket': bucket,
+            'Key': key
+        }
+        new_key = '%s.csv'%(key.split('0')[0])
+        self.conns3.meta.client.copy(copy_source, bucket, new_key)
 
 
-def load_ref_data_rds(urls, engine, tmp, uri):
-    print('Loading reference_data to RDS ...')
-    conn=engine.connect()
-    # creating dim_asn table here with other ref data
-    conn.execute('DROP TABLE IF EXISTS data__asn___asn CASCADE')
-    create_asn = 'CREATE TABLE data__asn___asn(number BIGINT, title TEXT, country TEXT)'
-    conn.execute(create_asn)
-    
-    for url in urls:
-        # Loading of asn with push_datapackage takes more then 2 hours
-        # So have to download localy and sasve (takes ~5 seconds)
-        if 'asn' not in url:
-            push_datapackage(descriptor=url,backend='sql',engine=conn)
-        else:
-            dp = datapackage.DataPackage(url)
-            # local path will be returned if not found remote one (fot tests)
-            url = dp.resources[0].remote_data_path or dp.resources[0].local_data_path
-            urllib.urlretrieve(url, join(tmp, 'dim_asn.csv'))
-            copy_command = dedent('''
-            psql {uri} -c "\COPY data__asn___asn FROM {tmp}/dim_asn.csv WITH delimiter as ',' csv header;"
-            ''')
-            os.system(copy_command.format(tmp=tmp,uri=uri))
-    conn.close()
-
-def create_rds_tables():
-    conn=connRDS.connect()
-    tablenames = [
-        'fact_count', 'agg_risk_country_week',
-        'agg_risk_country_month', 'agg_risk_country_quarter', 'dim_asn',
-        'agg_risk_country_year', 'dim_risk', 'dim_country', 'dim_time'
-    ]
-    drop_tables(conn, tablenames)
-    create_risk ='ALTER TABLE data__risk___risk RENAME TO dim_risk'
-    create_country = 'ALTER TABLE data__country___country RENAME TO dim_country'
-    create_asn = 'ALTER TABLE data__asn___asn RENAME TO dim_asn'
-    create_time = dedent('''
-    CREATE TABLE dim_time(
-        date DATE, month INT,
-        year INT, quarter INT,
-        week INT, week_start DATE,
-        week_end DATE
-        )''')
-    create_count = dedent('''
-    CREATE TABLE fact_count(
-        date DATE, risk INT,
-        country VARCHAR(2),
-        asn BIGINT, count BIGINT,
-        count_amplified FLOAT
-        )''')
-    create_cube = dedent('''
-    CREATE TABLE agg_risk_country_{time}(
-        date DATE, risk INT,
-        country VARCHAR(2),
-        count BIGINT,
-        count_amplified FLOAT
-        )''')
-
-    conn.execute(create_risk)
-    conn.execute(create_country)
-    conn.execute(create_asn)
-    conn.execute(create_time)
-    conn.execute(create_count)
-    create_or_update_cubes(conn, create_cube)
-    conn.close()
+    def delete_key(self, bucket, key):
+        self.conns3.Object(bucket, key).delete()
 
 
-def populate_tables():
-    print('Populating cubes')
-    conn=connRDS.connect()
-    update_time = dedent('''
-    INSERT INTO dim_time
-    (SELECT
-        date,
-        EXTRACT(MONTH FROM date) as month,
-        EXTRACT(YEAR FROM date) as year,
-        EXTRACT(QUARTER FROM date) as quarter,
-        EXTRACT(WEEK FROM date) as week,
-        date_trunc('week', date) as week_start,
-        (date_trunc('week', date)+'6 days') as week_end
-    FROM fact_count GROUP BY date)
-    ''')
-    populate_cube = dedent('''
-    INSERT INTO agg_risk_country_{time}
-        (SELECT date_trunc('{time}', date) AS date, risk, country, 
-        SUM(count) AS count, SUM(count_amplified) FROM fact_count
-    GROUP BY CUBE(date_trunc('{time}', date), country, risk) ORDER BY date DESC, country)
-    ''')
-    update_cube_risk = dedent('''
-    UPDATE agg_risk_country_{time}
-    SET risk=100
-    WHERE risk IS null;
-    ''')
-    update_cube_country = dedent('''
-    UPDATE agg_risk_country_{time}
-    SET country='T'
-    WHERE country IS null;
-    ''')
-    conn.execute(update_time)
-    create_or_update_cubes(conn, populate_cube)
-    create_or_update_cubes(conn, update_cube_risk)
-    create_or_update_cubes(conn, update_cube_country)
-    conn.close()
+class LoadToRDS(object):
+    def __init__(self, config):
+        self.config = config
+        self.tmpdir = tempfile.mkdtemp()
+        self.ref_data_urls = [inventory.get('url') for inventory in config.get('inventory')]
+        self.connRDS = create_engine(config.get('rds_uri'))
+        self.conns3 = boto3.resource(
+            's3',
+            aws_access_key_id=config.get('access_key'),
+            aws_secret_access_key=config.get('secret_key')
+        )
+        self.tablenames = [
+            'fact_count', 'agg_risk_country_week',
+            'agg_risk_country_month', 'agg_risk_country_quarter', 'dim_asn',
+            'agg_risk_country_year', 'dim_risk', 'dim_country', 'dim_date'
+        ]
 
 
-def create_constraints():
-    conn = connRDS.connect()
-    risk_constraints = 'ALTER TABLE dim_risk ADD PRIMARY KEY (id);'
-    country_constraints = 'ALTER TABLE dim_country ADD PRIMARY KEY (id);'
-    asn_constraints = '''
-    ALTER TABLE dim_asn
-    ADD PRIMARY KEY (number),
-    ADD CONSTRAINT fk_country_asn FOREIGN KEY (country) REFERENCES dim_country(id)
-    '''
-    time_constraints = 'ALTER TABLE dim_time ADD PRIMARY KEY (date)'
-    count_counstraints = dedent('''
-    ALTER TABLE fact_count
-    ADD CONSTRAINT fk_count_risk FOREIGN KEY (risk) REFERENCES dim_risk(id),
-    ADD CONSTRAINT fk_count_country FOREIGN KEY (country) REFERENCES dim_country(id),
-    ADD CONSTRAINT fk_count_asn FOREIGN KEY (asn) REFERENCES dim_asn(number),
-    ADD CONSTRAINT fk_count_time FOREIGN KEY (date) REFERENCES dim_time(date);
-    ''')
-    cube_counstraints = dedent('''
-    ALTER TABLE agg_risk_country_{time}
-    ADD CONSTRAINT fk_cube_risk_{time} FOREIGN KEY (risk) REFERENCES dim_risk(id),
-    ADD CONSTRAINT fk_cube_country_{time} FOREIGN KEY (country) REFERENCES dim_country(id)
-    ''')
-    conn.execute(risk_constraints)
-    conn.execute(country_constraints)
-    conn.execute(asn_constraints)
-    conn.execute(time_constraints)
-    conn.execute(count_counstraints)
-    create_or_update_cubes(conn, cube_counstraints)
-    conn.close()
+    def run(self):
+        self.load_ref_data_rds()
+        self.create_tables()
+        self.download_and_load()
+        self.populate_tables()
+        self.create_constraints()
+        self.create_indexes()
+        shutil.rmtree(self.tmpdir)
 
 
-def create_indexes():
-    conn = connRDS.connect()
-    idx_dict = {
-        # Index to speedup /api/v1/count
-        'idx_date_country': 'CREATE INDEX idx_date_country ON fact_count(date DESC, country);',
-        "idx_all": "CREATE INDEX idx_all ON fact_count(date, country, risk, asn);",
-        "idx_all_desc": "CREATE INDEX idx_all_desc ON fact_count(date DESC, country, risk, asn);",
-        "idx_risk": "CREATE INDEX idx_risk ON fact_count(risk);",
-        "idx_asn": "CREATE INDEX idx_asn ON fact_count(asn);",
-        "idx_country": "CREATE INDEX idx_country ON fact_count(country);",
-        "idx_date": "CREATE INDEX idx_date ON fact_count(date);",
-        "idx_all_cube": "CREATE INDEX idx_all_cube_{time} ON agg_risk_country_{time}(date, country, risk);",
-        "idx_all_desc_cube": "CREATE INDEX idx_all_desc_cube_{time} ON agg_risk_country_{time}(date DESC, country, risk);",
-        "idx_risk_cube": "CREATE INDEX idx_risk_cube_{time} ON agg_risk_country_{time}(risk);",
-        "idx_country_cube": "CREATE INDEX idx_country_cube_{time} ON agg_risk_country_{time}(country);",
-        "idx_date_cube": "CREATE INDEX idx_date_cube_{time} ON agg_risk_country_{time}(date);"
-    }
-    for idx in idx_dict:
-        if 'cube' not in idx:
-            conn.execute(idx_dict[idx])
-        else:
-            create_or_update_cubes(conn, idx_dict[idx])
-    conn.close()
+    def drop_tables(self, tables):
+        for tablename in tables:
+            self.connRDS.execute("DROP TABLE IF EXISTS %(table)s CASCADE",{"table": AsIs(tablename)})
 
 
-def drop_tables(cursor, tables):
-    for tablename in tables:
-        cursor.execute("DROP TABLE IF EXISTS %(table)s CASCADE",{"table": AsIs(tablename)})
+    def download_and_load(self):
+        print('Downloading csv file ...')
+        bucket, key = split_s3_path(self.config.get('dest_path'))
+        s3paths = [(join(self.tmpdir,'count.csv'),join(key,'count.csv'))]
+        bucket = self.conns3.Bucket(bucket)
+        for path in s3paths:
+            bucket.download_file(path[1], path[0])
+
+        print('Loading into RDS ...')
+        copy_command = dedent('''
+        psql {uri} -c "\COPY fact_count FROM {tmp}/count.csv WITH delimiter as ',' null '' csv;"
+        ''')
+        os.system(copy_command.format(tmp=self.tmpdir,uri=self.config.get('rds_uri')))
 
 
-def create_or_update_cubes(conn, cmd):
-    time_granularities = [
-        'week', 'month', 'quarter', 'year'
-    ]
-    for time in time_granularities:
-        conn.execute(cmd.format(time=time))
+    def load_ref_data_rds(self):
+        print('Loading reference_data to RDS ...')
+        conn = self.connRDS.connect()
+        # creating dim_asn table here with other ref data
+        conn.execute('DROP TABLE IF EXISTS data__asn___asn CASCADE')
+        create_asn = 'CREATE TABLE data__asn___asn(number BIGINT, title TEXT, country TEXT)'
+        conn.execute(create_asn)
+
+        for url in self.ref_data_urls:
+            # Loading of asn with push_datapackage takes more then 2 hours
+            # So have to download localy and sasve (takes ~5 seconds)
+            if 'asn' not in url:
+                push_datapackage(descriptor=url,backend='sql',engine=conn)
+            else:
+                dp = datapackage.DataPackage(url)
+                # local path will be returned if not found remote one (fot tests)
+                url = dp.resources[0].remote_data_path or dp.resources[0].local_data_path
+                urllib.urlretrieve(url, join(self.tmpdir, 'asn.csv'))
+                copy_command = dedent('''
+                psql {uri} -c "\COPY data__asn___asn FROM {tmp}/asn.csv WITH delimiter as ',' csv header;"
+                ''')
+                os.system(copy_command.format(tmp=self.tmpdir,uri=self.config.get('rds_uri')))
+        conn.close()
 
 
-def run_redshift(tmpdir):
-    table_name = 'count'
-    upload_manifest(tmpdir)
-    create_redshift_tables()
-    load_ref_data()
-    load_data()
-    count_data()
-    aggregate()
-    update_amplified_count()
-    unload(table_name)
+    def create_tables(self):
+        conn=self.connRDS.connect()
+        self.drop_tables(self.tablenames)
+        create_risk ='ALTER TABLE data__risk___risk RENAME TO dim_risk'
+        create_country = 'ALTER TABLE data__country___country RENAME TO dim_country'
+        create_asn = 'ALTER TABLE data__asn___asn RENAME TO dim_asn'
+        create_time = dedent('''
+        CREATE TABLE dim_date(
+            date DATE, month INT,
+            year INT, quarter INT,
+            week INT, week_start DATE,
+            week_end DATE
+            )''')
+        create_count = dedent('''
+        CREATE TABLE fact_count(
+            date DATE, risk INT,
+            country VARCHAR(2),
+            asn BIGINT, count BIGINT,
+            count_amplified FLOAT
+            )''')
+        create_cube = dedent('''
+        CREATE TABLE agg_risk_country_{time}(
+            date DATE, risk INT,
+            country VARCHAR(2),
+            count BIGINT,
+            count_amplified FLOAT
+            )''')
+
+        conn.execute(create_risk)
+        conn.execute(create_country)
+        conn.execute(create_asn)
+        conn.execute(create_time)
+        conn.execute(create_count)
+        self.create_or_update_cubes(conn, create_cube)
+        conn.close()
 
 
-def run_rds(tmpdir):
-    load_ref_data_rds(REF_DATA_URLS, connRDS, tmpdir, config['rds_uri'])
-    create_rds_tables()
-    download_and_load(tmpdir)
-    populate_tables()
-    create_constraints()
-    create_indexes()
+    def create_or_update_cubes(self, conn, cmd):
+        time_granularities = [
+            'week', 'month', 'quarter', 'year'
+        ]
+        for time in time_granularities:
+            conn.execute(cmd.format(time=time))
+
+
+    def populate_tables(self):
+        print('Populating cubes')
+        conn=self.connRDS.connect()
+        update_date = dedent('''
+        INSERT INTO dim_date
+        (SELECT
+            date,
+            EXTRACT(MONTH FROM date) as month,
+            EXTRACT(YEAR FROM date) as year,
+            EXTRACT(QUARTER FROM date) as quarter,
+            EXTRACT(WEEK FROM date) as week,
+            date_trunc('week', date) as week_start,
+            (date_trunc('week', date)+'6 days') as week_end
+        FROM fact_count GROUP BY date)
+        ''')
+        populate_cube = dedent('''
+        INSERT INTO agg_risk_country_{time}
+            (SELECT date_trunc('{time}', date) AS date, risk, country,
+            SUM(count) AS count, SUM(count_amplified) FROM fact_count
+        GROUP BY CUBE(date_trunc('{time}', date), country, risk) ORDER BY date DESC, country)
+        ''')
+        update_cube_risk = dedent('''
+        UPDATE agg_risk_country_{time}
+        SET risk=100
+        WHERE risk IS null;
+        ''')
+        update_cube_country = dedent('''
+        UPDATE agg_risk_country_{time}
+        SET country='T'
+        WHERE country IS null;
+        ''')
+        conn.execute(update_date)
+        self.create_or_update_cubes(conn, populate_cube)
+        self.create_or_update_cubes(conn, update_cube_risk)
+        self.create_or_update_cubes(conn, update_cube_country)
+        conn.close()
+
+
+    def create_constraints(self):
+        conn = self.connRDS.connect()
+        risk_constraints = 'ALTER TABLE dim_risk ADD PRIMARY KEY (id);'
+        country_constraints = 'ALTER TABLE dim_country ADD PRIMARY KEY (id);'
+        asn_constraints = '''
+        ALTER TABLE dim_asn
+        ADD PRIMARY KEY (number),
+        ADD CONSTRAINT fk_country_asn FOREIGN KEY (country) REFERENCES dim_country(id)
+        '''
+        time_constraints = 'ALTER TABLE dim_date ADD PRIMARY KEY (date)'
+        count_counstraints = dedent('''
+        ALTER TABLE fact_count
+        ADD CONSTRAINT fk_count_risk FOREIGN KEY (risk) REFERENCES dim_risk(id),
+        ADD CONSTRAINT fk_count_country FOREIGN KEY (country) REFERENCES dim_country(id),
+        ADD CONSTRAINT fk_count_asn FOREIGN KEY (asn) REFERENCES dim_asn(number),
+        ADD CONSTRAINT fk_count_time FOREIGN KEY (date) REFERENCES dim_date(date);
+        ''')
+        cube_counstraints = dedent('''
+        ALTER TABLE agg_risk_country_{time}
+        ADD CONSTRAINT fk_cube_risk_{time} FOREIGN KEY (risk) REFERENCES dim_risk(id),
+        ADD CONSTRAINT fk_cube_country_{time} FOREIGN KEY (country) REFERENCES dim_country(id)
+        ''')
+        conn.execute(risk_constraints)
+        conn.execute(country_constraints)
+        conn.execute(asn_constraints)
+        conn.execute(time_constraints)
+        conn.execute(count_counstraints)
+        self.create_or_update_cubes(conn, cube_counstraints)
+        conn.close()
+
+
+    def create_indexes(self):
+        conn = self.connRDS.connect()
+        idx_dict = {
+            # Index to speedup /api/v1/count
+            'idx_date_country': 'CREATE INDEX idx_date_country ON fact_count(date DESC, country);',
+            "idx_all": "CREATE INDEX idx_all ON fact_count(date, country, risk, asn);",
+            "idx_all_desc": "CREATE INDEX idx_all_desc ON fact_count(date DESC, country, risk, asn);",
+            "idx_risk": "CREATE INDEX idx_risk ON fact_count(risk);",
+            "idx_asn": "CREATE INDEX idx_asn ON fact_count(asn);",
+            "idx_country": "CREATE INDEX idx_country ON fact_count(country);",
+            "idx_date": "CREATE INDEX idx_date ON fact_count(date);",
+            "idx_all_cube": "CREATE INDEX idx_all_cube_{time} ON agg_risk_country_{time}(date, country, risk);",
+            "idx_all_desc_cube": "CREATE INDEX idx_all_desc_cube_{time} ON agg_risk_country_{time}(date DESC, country, risk);",
+            "idx_risk_cube": "CREATE INDEX idx_risk_cube_{time} ON agg_risk_country_{time}(risk);",
+            "idx_country_cube": "CREATE INDEX idx_country_cube_{time} ON agg_risk_country_{time}(country);",
+            "idx_date_cube": "CREATE INDEX idx_date_cube_{time} ON agg_risk_country_{time}(date);"
+        }
+        for idx in idx_dict:
+            if 'cube' not in idx:
+                conn.execute(idx_dict[idx])
+            else:
+                self.create_or_update_cubes(conn, idx_dict[idx])
+        conn.close()
 
 
 if __name__ == '__main__':
-    tmpdir = tempfile.mkdtemp()
-    # run_redshift(tmpdir)
-    run_rds(tmpdir)
-    shutil.rmtree(tmpdir)
+    config = load_config(rpath('config.json'))
+    aggregator = Aggregator(config)
+    aggregator.run()
+    loader = LoadToRDS(config)
+    loader.run()

--- a/tests/aggregation_tests.py
+++ b/tests/aggregation_tests.py
@@ -8,35 +8,20 @@ import json
 import os
 
 from StringIO import StringIO
-from tempfile import NamedTemporaryFile
 from textwrap import dedent
 
 from psycopg2.extensions import AsIs
 from sqlalchemy import create_engine
-from nose.plugins.attrib import attr
-from mock import patch
 
-# seting env variables for testing
-os.environ["CYBERGREEN_BUILD_ENV"] = ''
-os.environ["RDS_PASSWORD"] = ''
-os.environ["REDSHIFT_PASSWORD"] = ''
-os.environ["CYBERGREEN_SOURCE_ROOT"] = ''
-os.environ["CYBERGREEN_DEST_ROOT"] = ''
-os.environ["CYBERGREEN_BUILD_ENV"] = ''
-os.environ["AWS_ACCESS_KEY_ID"] = ''
-os.environ["AWS_SECRET_ACCESS_KEY"] = ''
+from main import Aggregator, LoadToRDS
 
-import main
-
-connRedshift = create_engine('postgres://cg_test_user:secret@localhost/cg_test_db')
-connRDS = create_engine('postgres://cg_test_user:secret@localhost/cg_test_db')
+config = json.loads(open('tests/config.test.json').read())
 
 class RedshiftFunctionsTestCase(unittest.TestCase):
     # Test aggregation functions by week, ip, country and risk.
 
     def setUp(self):
-        # Patch main connection with the test one.
-        patch('main.connRedshift', connRedshift).start()
+        self.aggregator = Aggregator(config=config)
 
         # reference data with amplification factors
         self.scan_csv = dedent('''\
@@ -47,19 +32,16 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         5,,,30.8,
         ''')
         # set configurations
-        self.config = {"inventory": [{
-            "name": 'risk', "url": "tests/fixtures/risk-datapackage.json"
-            }]}
-        self.cursor = main.connRedshift.raw_connection().cursor()
+        self.cursor = self.aggregator.connRedshift.raw_connection().cursor()
         # create tables
-        main.create_redshift_tables()
+        self.aggregator.create_tables()
 
 
     def test_all_tables_created(self):
         '''
         Checks if all necessary tables are created for redshift
         '''
-        main.create_redshift_tables()
+        self.aggregator.create_tables()
         self.cursor.execute(
             'select exists(select * from information_schema.tables where table_name=%(table)s)',
             {'table': 'logentry'})
@@ -78,18 +60,24 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         '''
         Checks if tebles ar dropped
         '''
-        main.drop_tables(main.connRedshift, ['logentry', 'count', 'dim_risk'])
+        self.aggregator.drop_tables(
+            self.aggregator.connRedshift,
+            ['logentry', 'count', 'dim_risk']
+        )
         self.cursor.execute(
             'select exists(select * from information_schema.tables where table_name=%(table)s)',
-            {'table': 'logentry'})
+            {'table': 'logentry'}
+        )
         self.assertEqual(self.cursor.fetchone()[0], False)
         self.cursor.execute(
             'select exists(select * from information_schema.tables where table_name=%(table)s)',
-            {'table': 'count'})
+            {'table': 'count'}
+        )
         self.assertEqual(self.cursor.fetchone()[0], False)
         self.cursor.execute(
             'select exists(select * from information_schema.tables where table_name=%(table)s)',
-            {'table': 'dim_risk'})
+            {'table': 'dim_risk'}
+        )
         self.assertEqual(self.cursor.fetchone()[0], False)
 
 
@@ -98,7 +86,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         Checks if reference data is loaded from given url
         '''
         # load data
-        main.load_ref_data(self.config)
+        self.aggregator.load_ref_data()
         self.cursor.execute('SELECT * FROM dim_risk')
         self.assertEqual(self.cursor.fetchone(), (0, u'test-risk', u'Test Risk', 0.13456, u''))
 
@@ -117,14 +105,14 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         ''')
         self.cursor.copy_expert('COPY logentry from STDIN csv header', StringIO(scan_csv))
 
-        main.aggregate()
+        self.aggregator.aggregate()
 
         # count table should have 2 entries - 1 with cout of 2 and other with count of 1
         self.cursor.execute('select * from count;')
         self.assertEqual(
             self.cursor.fetchall(),
             [
-                (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 1, 0.0),  
+                (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 1, 0.0),
                 (datetime.datetime(2016, 9, 20, 0, 0), 2, 'US', 12252L, 2, 0.0) # grouped two entries
             ])
 
@@ -143,14 +131,14 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         ''')
         self.cursor.copy_expert("COPY logentry from STDIN csv header", StringIO(scan_csv))
 
-        main.aggregate()
+        self.aggregator.aggregate()
 
         # count table should have 2 entries with 1 count each
         self.cursor.execute('select * from count;')
         self.assertEqual(
             self.cursor.fetchall(),
             [
-                (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 1, 0.0),  
+                (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 1, 0.0),
                 (datetime.datetime(2016, 9, 20, 0, 0), 2, 'US', 12252L, 1, 0.0)
             ])
 
@@ -170,14 +158,14 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         ''')
         self.cursor.copy_expert("COPY logentry from STDIN csv header", StringIO(scan_csv))
 
-        main.aggregate()
+        self.aggregator.aggregate()
 
         #count table should have 2 rows corresponding to different risks, with properly grouped entries
         self.cursor.execute('select * from count;')
         self.assertEqual(
             self.cursor.fetchall(),
             [
-                (datetime.datetime(2016, 9, 29, 0, 0), 1, 'US', 12252L, 1, 0.0),  
+                (datetime.datetime(2016, 9, 29, 0, 0), 1, 'US', 12252L, 1, 0.0),
                 (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 2, 0.0)
             ])
 
@@ -195,7 +183,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         ''')
         self.cursor.copy_expert("COPY logentry from STDIN csv header", StringIO(scan_csv))
 
-        main.aggregate()
+        self.aggregator.aggregate()
 
         # count table should have 2 entries - US with count of 2, and DE with count of 1
         self.cursor.execute('select * from count;')
@@ -203,7 +191,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
             self.cursor.fetchall(),
             [
                 (datetime.datetime(2016, 9, 29, 0, 0), 2, 'DE', 3333L, 1, 0.0),
-                (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 2, 0.0)  
+                (datetime.datetime(2016, 9, 29, 0, 0), 2, 'US', 12252L, 2, 0.0)
             ])
 
 
@@ -220,7 +208,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         ''')
         self.cursor.copy_expert("COPY logentry from STDIN csv header", StringIO(scan_csv))
 
-        main.aggregate()
+        self.aggregator.aggregate()
 
         # count table should have 2 entries - AS 12252 with count of 2, and AS 3333 with count of 1
         self.cursor.execute('select * from count;')
@@ -261,7 +249,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         ''')
         self.cursor.copy_expert("COPY logentry from STDIN csv header", StringIO(scan_csv))
 
-        main.aggregate()
+        self.aggregator.aggregate()
 
         # count table should have 2 entries - US with count of 2, and DE with count of 1
         self.cursor.execute('select * from count;')
@@ -292,7 +280,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         Checks if amplified counts are calculated correctly for each risk
         '''
         # recreate tables
-        main.create_redshift_tables()
+        self.aggregator.create_tables()
         # GIVEN 4 entries of the same day, country, ASN an IP but different risks
         scan_csv = dedent('''\
         ts,ip,risk_id,asn,cc
@@ -305,8 +293,8 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         # import ref data
         self.cursor.copy_expert("COPY dim_risk from STDIN csv header", StringIO(self.scan_csv))
 
-        main.aggregate()
-        main.update_amplified_count()
+        self.aggregator.aggregate()
+        self.aggregator.update_amplified_count()
         self.maxDiff = None
 
         self.cursor.execute('select * from count;')
@@ -325,7 +313,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         Checks if amplified counts are calculated correctly for each risk when grouped
         '''
         # recreate tables
-        main.create_redshift_tables()
+        self.aggregator.create_tables()
         # GIVEN 4 entries of the same day, country, ASN, but different risks
         scan_csv = dedent('''\
         ts,ip,risk_id,asn,cc
@@ -348,8 +336,8 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
         # import ref data
         self.cursor.copy_expert("COPY dim_risk from STDIN csv header", StringIO(self.scan_csv))
 
-        main.aggregate()
-        main.update_amplified_count()
+        self.aggregator.aggregate()
+        self.aggregator.update_amplified_count()
         self.maxDiff = None
 
         self.cursor.execute('select * from count;')
@@ -364,7 +352,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
 
 
     def tearDown(self):
-        main.drop_tables(main.connRedshift, ['logentry', 'count', 'dim_risk'])
+        self.aggregator.drop_tables(self.aggregator.connRedshift, ['logentry', 'count', 'dim_risk'])
 
 
 
@@ -372,17 +360,13 @@ class RDSFunctionsTestCase(unittest.TestCase):
     # Test aggregation functions by week, ip, country and risk.
 
     def setUp(self):
-        # Patch main connection with the test one.
-        patch('main.connRDS', connRDS).start()
-
-        self.cursor = main.connRDS.raw_connection().cursor()
-        self.tmpdir = tempfile.mkdtemp()
-
+        self.loader = LoadToRDS(config=config)
+        self.cursor = self.loader.connRDS.raw_connection().cursor()
         self.tablenames = [
             'fact_count', 'agg_risk_country_week',
             'agg_risk_country_month', 'agg_risk_country_quarter',
-            'agg_risk_country_year', 'dim_risk', 'dim_country', 
-            'dim_asn', 'dim_time'
+            'agg_risk_country_year', 'dim_risk', 'dim_country',
+            'dim_asn', 'dim_date'
         ]
         # snipet for fact_count table
         self.counts = dedent('''
@@ -392,17 +376,12 @@ class RDSFunctionsTestCase(unittest.TestCase):
         2014-10-21,0,ZZ,999999,4,25.2
         2014-10-03,0,AA,111111,2,1113.8
         ''')
-        # set configurations
-        self.urls = ['tests/fixtures/risk-datapackage.json',
-                     'tests/fixtures/country-datapackage.json',
-                     'tests/fixtures/asn-datapackage.json']
         # drops temporay tables for ref data if exsists
-        main.drop_tables(main.connRDS, self.tablenames)
-        main.drop_tables(main.connRDS, ['data__risk___risk',
+        self.loader.drop_tables(self.tablenames)
+        self.loader.drop_tables(['data__risk___risk',
                                         'data__country___country',
                                         'data__asn___asn'])
-        self.uri = 'postgres://cg_test_user:secret@localhost/cg_test_db'
-        main.load_ref_data_rds(self.urls, main.connRDS, self.tmpdir, self.uri)
+        self.loader.load_ref_data_rds()
 
 
     def test_reference_tables_created(self):
@@ -421,8 +400,8 @@ class RDSFunctionsTestCase(unittest.TestCase):
             'select exists(select * from information_schema.tables where table_name=%(table)s)',
             {'table': 'data__asn___asn'})
         self.assertEqual(self.cursor.fetchone()[0], True)
-    
-    
+
+
     def test_reference_data_loaded_in_temptables(self):
         '''
         Ckecks if ref data is loaded in tem tables
@@ -435,13 +414,13 @@ class RDSFunctionsTestCase(unittest.TestCase):
                          (u'AA', u'Test country', u'test-country', u'test-regiton', u'test-continent'))
         self.cursor.execute('SELECT * FROM data__asn___asn')
         self.assertEqual(self.cursor.fetchone(), (111111.0, u'Test title', u'AA'))
-    
-    
+
+
     def test_rds_tables_created(self):
         '''
         Checks if all rds tables are created and temptables renamed
         '''
-        main.create_rds_tables()
+        self.loader.create_tables()
         message='Table %(table) is not created'
         for table in self.tablenames:
             self.cursor.execute(
@@ -449,53 +428,73 @@ class RDSFunctionsTestCase(unittest.TestCase):
                 {'table': table})
             # If there is no table cursor.fetchone() will return None and fail
             self.assertEqual(self.cursor.fetchone()[0], table, msg=message.format(table=table))
-    
-    
+
+
     def test_populate_rds_tables(self):
         '''
         Checks if rds tables are populated
         '''
         message = 'Table {table} is empty'
         # Create tables and pouplate fact_cunt
-        main.create_rds_tables()
-        self.cursor.copy_expert("COPY fact_count from STDIN csv header", StringIO(self.counts))
+        self.loader.create_tables()
+        self.loader.connRDS.connect().execute(dedent("""
+            INSERT INTO fact_count
+            VALUES
+                ('2016-09-03',0,'AA',111111,1,30.8),
+                ('2016-11-13',0,'ZZ',999999,33,1353),
+                ('2016-05-22',0,'AA',111111,10,410),
+                ('2014-10-21',0,'ZZ',999999,4,25.2),
+                ('2014-10-03',0,'AA',111111,2,1113.8)
+            """))
+        self.loader.connRDS.connect().close()
+        self.loader.populate_tables()
         # After running populate tables
-        main.populate_tables()
         # If there is no entry cursor.fetchone() will return None and fail
         for table in self.tablenames:
             self.cursor.execute('SELECT * FROM %(table)s LIMIT 1',{"table": AsIs(table)})
             self.assertNotEqual(self.cursor.fetchone(), None, msg=message.format(table=table))
-    
-    
+
+
     def test_create_constraints(self):
         '''
         Checks if all constraints are created
         '''
         c_names = [
-            'dim_risk_pkey', 'dim_country_pkey', 'dim_asn_pkey', 'dim_time_pkey',
+            'dim_risk_pkey', 'dim_country_pkey', 'dim_asn_pkey', 'dim_date_pkey',
             'fk_country_asn', 'fk_count_risk', 'fk_count_country', 'fk_count_asn',
             'fk_count_time', 'fk_cube_risk_week','fk_cube_risk_month', 'fk_cube_risk_quarter',
             'fk_cube_risk_year', 'fk_cube_country_week', 'fk_cube_country_month',
             'fk_cube_country_quarter','fk_cube_country_year']
         message = 'Constraint {c_name} is not created'
         # Create tables and pouplate them
-        main.create_rds_tables()
-        self.cursor.copy_expert("COPY fact_count from STDIN csv header", StringIO(self.counts))
-        main.populate_tables()
-        main.create_constraints()
+        self.loader.create_tables()
+        self.loader.connRDS.connect().execute(dedent("""
+            INSERT INTO fact_count
+            VALUES
+                ('2016-09-03',0,'AA',111111,1,30.8),
+                ('2016-11-13',0,'ZZ',999999,33,1353),
+                ('2016-05-22',0,'AA',111111,10,410),
+                ('2014-10-21',0,'ZZ',999999,4,25.2),
+                ('2014-10-03',0,'AA',111111,2,1113.8)
+            """))
+        self.loader.populate_tables()
+        self.loader.create_constraints()
         for c_name in c_names:
             self.cursor.execute("select constraint_name from information_schema.table_constraints WHERE constraint_name = %(c_name)s",
                                 {'c_name': c_name})
             # If there is no constraint cursor.fetchone() will return None and fail
             self.assertEqual(self.cursor.fetchone()[0], c_name, msg=message.format(c_name=c_name))
-        
-        ## TODO: check indexes created
-    
+
+        # TODO: check indexes created
+
     def tearDown(self):
-        main.drop_tables(main.connRDS, self.tablenames)
+        self.loader.drop_tables(self.tablenames)
 
 
 class MetadataTestCase(unittest.TestCase):
+    def setUp(self):
+        self.aggregator = Aggregator(config=config)
+
 
     def test_create_manifest(self):
         '''
@@ -524,5 +523,5 @@ class MetadataTestCase(unittest.TestCase):
             {'url': u's3://test.bucket/test/key/dns-scan/dns-scan.20000101.csv.gz',
              'mandatory': True}
             ]}
-        manifest = main.create_manifest(datapackage, 's3://test.bucket/test/key')
+        manifest = self.aggregator.create_manifest(datapackage, 's3://test.bucket/test/key')
         self.assertEquals(manifest,expected_manifest)

--- a/tests/aggregation_tests.py
+++ b/tests/aggregation_tests.py
@@ -364,7 +364,7 @@ class RedshiftFunctionsTestCase(unittest.TestCase):
 
 
     def tearDown(self):
-        main.drop_tables(main.connRedshift, ['logentry', 'count', 'dim_risk','tmp_count'])
+        main.drop_tables(main.connRedshift, ['logentry', 'count', 'dim_risk'])
 
 
 

--- a/tests/config.test.json
+++ b/tests/config.test.json
@@ -1,0 +1,23 @@
+{
+  "rds_uri": "postgres://cg_test_user:secret@localhost/cg_test_db",
+  "redshift_uri": "postgres://cg_test_user:secret@localhost/cg_test_db",
+  "role_arn":"",
+  "source_path": "",
+  "dest_path": "",
+  "access_key":"",
+  "secret_key":"",
+  "inventory" : [
+    {
+      "name":"risk",
+      "url":"tests/fixtures/risk-datapackage.json"
+    },
+    {
+      "name":"country",
+      "url":"tests/fixtures/country-datapackage.json"
+    },
+    {
+      "name":"asn",
+      "url":"tests/fixtures/asn-datapackage.json"
+    }
+  ]
+}


### PR DESCRIPTION
PR includes Two general changes for aggregator script: 
- Actual aggregator part separated into `Aggregator` module, that accepts configurations and Can be used only for loading data from s3, aggregating and unloading back to s3
- Part that was responsible for loading data from s3 to RDS and populating cubes separated into `LoadToRDS` module and also accepts config.

PR also includes small refactoring for tests as `Aggregator` and `LoadToRDS` modules are now importable and instead of old functions now their methods are tested

Useless imports removed 

refs and closes #42 