### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsontableschema-sql
-datapackage
+datapackage<1.0
 sqlalchemy
 psycopg2
 boto3


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.